### PR TITLE
package name changed to cordova-plugin-google-app-conversion-tracker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "GoogleAppTracking",
+  "name": "cordova-plugin-google-app-conversion-tracker",
   "version": "0.0.2",
   "description": "Cordova Plugin for Google App Install Conversion Tracking",
   "cordova": {
-    "id": "com.test.google-app-conversion-tracker",
+    "id": "cordova-plugin-google-app-conversion-tracker",
     "platforms": [
       "ios",
       "android"
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/VivreTech/google-app-conversion-tracker.git"
+    "url": "git+https://github.com/MyHealthTeams/google-app-conversion-tracker.git"
   },
   "keywords": [
     "ecosystem:cordova",
@@ -27,7 +27,7 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/VivreTech/google-app-conversion-tracker/issues"
+    "url": "https://github.com/MyHealthTeams/google-app-conversion-tracker/issues"
   },
-  "homepage": "https://github.com/VivreTech/google-app-conversion-tracker#readme"
+  "homepage": "https://github.com/MyHealthTeams/google-app-conversion-tracker#readme"
 }


### PR DESCRIPTION
This should solve all installation problems described in #8.

The package `name` must equal the plugin id in the `plugin.xml` file or you get tons of installation problems with cordova. Internally cordova's plugin installation process creates a diff each time it adds a plugin to the platform. This process fails when the plugin id differs from the installed package name. In this case the package `GoogleAppTracking` gets installed but it is unable to determine a plugin with id `cordova-plugin-google-app-conversion-tracker`.

It would also be nice if you could publish the plugin via npm. So we could then change the installation process to

```
cordova plugin add cordova-plugin-google-app-conversion-tracker
```